### PR TITLE
HOW_TO_RUN.mdをちょっと修正

### DIFF
--- a/HOW_TO_RUN.md
+++ b/HOW_TO_RUN.md
@@ -1,6 +1,6 @@
-# IntelliJ IDEを使う場合
+# IntelliJ IDEAを使う場合
 
-* IntelliJ IDEの導入
+* IntelliJ IDEAの導入
   * https://www.jetbrains.com/idea/download/
   * OSによってリンク先の指示に従ってインストールする
 * Mavenプラグインの導入
@@ -16,20 +16,21 @@
 * 実行する
   * ツールバー[実行]→[実行]
   * 以下のような結果が得られる
-```
-"java" ...
-1
-2
-3
-4
-5
-6
-7
-8
-9
+  
+     ```
+     "java" ...
+     1
+     2
+     3
+     4
+     5
+     6
+     7
+     8
+     9
 
-Process finished with exit code 0
-```
+     Process finished with exit code 0
+   ```
 
 # 端末を使う場合
 


### PR DESCRIPTION
正式な名称は"IntelliJ IDE"ではなく"InTelliJ IDEA"かと思います。

また、コードブロックがリストの要素ほどインデントしておらずリストの要素として含まれていないのも気になったので直しておきました。